### PR TITLE
Twitter provider failed because of $request scope.

### DIFF
--- a/lib/Dancer2/Plugin/Auth/OAuth/Provider.pm
+++ b/lib/Dancer2/Plugin/Auth/OAuth/Provider.pm
@@ -147,7 +147,7 @@ sub callback {
     my $session_data = $session->read('oauth') || {};
 
     if( $self->protocol_version < 2 ) {
-        my $request = Net::OAuth->request( 'access token' )->new(
+        my $at_request = Net::OAuth->request( 'access token' )->new(
            $self->_default_args_v1,
             token          => $request->param('oauth_token'),
             token_secret   => '',
@@ -156,9 +156,9 @@ sub callback {
             request_url    => $self->provider_settings->{urls}{access_token_url},
             request_method => 'POST'
         );
-        $request->sign;
+        $at_request->sign;
 
-        my $ua_response = $self->ua->request( GET $request->to_url );
+        my $ua_response = $self->ua->request( GET $at_request->to_url );
 
         if( $ua_response->is_success ) {
             my $response = Net::OAuth->response( 'access token' )->from_post_body( $ua_response->content );

--- a/lib/Dancer2/Plugin/Auth/OAuth/Provider.pm
+++ b/lib/Dancer2/Plugin/Auth/OAuth/Provider.pm
@@ -11,6 +11,7 @@ use LWP::UserAgent;
 use Net::OAuth;
 use Scalar::Util qw( blessed );
 use URI::Query;
+use Data::Dump qw(pp);
 
 sub new {
     my ($class, $settings) = @_;
@@ -147,7 +148,7 @@ sub callback {
     my $session_data = $session->read('oauth') || {};
 
     if( $self->protocol_version < 2 ) {
-        my $request = Net::OAuth->request( 'access token' )->new(
+        my $at_request = Net::OAuth->request( 'access token' )->new(
            $self->_default_args_v1,
             token          => $request->param('oauth_token'),
             token_secret   => '',
@@ -156,9 +157,9 @@ sub callback {
             request_url    => $self->provider_settings->{urls}{access_token_url},
             request_method => 'POST'
         );
-        $request->sign;
+        $at_request->sign;
 
-        my $ua_response = $self->ua->request( GET $request->to_url );
+        my $ua_response = $self->ua->request( GET $at_request->to_url );
 
         if( $ua_response->is_success ) {
             my $response = Net::OAuth->response( 'access token' )->from_post_body( $ua_response->content );


### PR DESCRIPTION
The callback is working as I see it with the oauth_token and oauth_verifier.
Then the access_token_url fails with:

"Error processing your OAuth request: Invalid oauth_verifier parameter"

The "access_token_url" is not including the oauth_verifier

Just changed $request to $at_request on Net::OAuth 'access token' request.
Was using perl v5.22
