### PR TITLE
don't 'use Dancer2' since this breaks compat with new Plugin code

### DIFF
--- a/lib/Dancer2/Plugin/Auth/OAuth.pm
+++ b/lib/Dancer2/Plugin/Auth/OAuth.pm
@@ -4,7 +4,6 @@ use strict;
 use 5.008_005;
 our $VERSION = '0.08';
 
-use Dancer2;
 use Dancer2::Plugin;
 use Module::Load;
 


### PR DESCRIPTION
New Dancer2::Plugin (not yet released) breaks when a plugin imports
Dancer2 package. Plugins do not need to 'use Dancer2'.
