### PR TITLE
Since Facebook API v2.4 the facebook provider is not working as it should

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The YAML below shows all available options.
             tokens:
               client_id: your_client_id
               client_secret: your_client_secret
+            fields: id,email,name,gender,picture
           Google:
             tokens:
               client_id: your_client_id

--- a/lib/Dancer2/Plugin/Auth/OAuth/Provider/Facebook.pm
+++ b/lib/Dancer2/Plugin/Auth/OAuth/Provider/Facebook.pm
@@ -15,7 +15,7 @@ sub config { {
     query_params => {
         authorize => {
             response_type => 'code',
-            scope         => 'email',
+            scope         => 'email,public_profile,user_friends',
         }
     }
 } }
@@ -23,11 +23,17 @@ sub config { {
 sub post_process {
     my ($self, $session) = @_;
 
+    my $fields = '';
+    if ( exists $self->provider_settings->{fields} ) {
+        $fields = "&fields=".$self->provider_settings->{fields};
+    }
+
     my $session_data = $session->read('oauth');
 
     my $resp = $self->{ua}->request(
         GET $self->provider_settings->{urls}{user_info}."?access_token=".
-            $session_data->{facebook}{access_token}
+            $session_data->{facebook}{access_token}.
+            $fields
     );
 
     if( $resp->is_success ) {


### PR DESCRIPTION
   Since Facebook Graph API v2.4 you need to specify which fields you want
    to receive.

```
https://developers.facebook.com/bugs/298946933534016/

(...) In Graph API v2.4 or higher, you must explicitly ask for the
'email' field of the user object (e.g. /v2.5/me?fields=email) even if
the 'email' permission scope is granted, and the user has a reachable
email address on file - this is due to the "Declarative Fields' entry in
the changelog [https://developers.facebook.com/docs/apps/changelog] and
applies to most fields of most objects in the API (...)

Even with the scope 'email' you just receive the 'id' and
'name'. There is no 'email'.

Just test it here:

https://developers.facebook.com/tools/explorer?method=GET&path=me&version=v2.6

With this modification you can get the old behaviour specifing the
fields on the config file 'config.yml'. Even better! Add 'picture' to get the
profile/avatar photo and 'token_for_business' to identify the same user
across several apps/web belonging to you.

Example to replicate the behaviour from v2.0:

plugins:
    "Auth::OAuth"
        providers:
            Facebook:
                tokens:
                    client_id: 1111111111111111
                    client_secret: aaaaaaaaaaaaaaaaaaaaaa
                fields: email,first_name,gender,id,last_name,link,locale,middle_name,name,timezone,updated_time,verified

Or a simpler one assuming you are using the same user database for
several sites or apps:

    fields: token_for_business,email,id,name,gender,picture
```
