### PR TITLE
Replace config ||= with Hash::Merge

### DIFF
--- a/META.json
+++ b/META.json
@@ -46,6 +46,7 @@
             "LWP::UserAgent" : "0",
             "Module::Load" : "0",
             "Net::OAuth" : "0",
+            "Hash::Merge" : "0",
             "Scalar::Util" : "0",
             "URI::Query" : "0",
             "perl" : "5.008005"
@@ -86,4 +87,3 @@
    "x_serialization_backend" : "Cpanel::JSON::XS version 3.0210",
    "x_spdx_expression" : "Artistic-1.0-Perl OR GPL-1.0-or-later"
 }
-

--- a/cpanfile
+++ b/cpanfile
@@ -10,6 +10,7 @@ requires 'URI::Query';
 requires 'HTTP::Message';
 requires 'LWP::Protocol::https';
 requires 'LWP::UserAgent';
+requires 'Hash::Merge';
 
 on test => sub {
     requires 'Plack::Test';

--- a/lib/Dancer2/Plugin/Auth/OAuth/Provider.pm
+++ b/lib/Dancer2/Plugin/Auth/OAuth/Provider.pm
@@ -11,6 +11,7 @@ use LWP::UserAgent;
 use Net::OAuth;
 use Scalar::Util qw( blessed );
 use URI::Query;
+use Hash::Merge;
 
 sub new {
     my ($class, $settings) = @_;
@@ -18,9 +19,9 @@ sub new {
         settings => $settings,
     }, $class;
 
-    for my $default (keys %{$self->config}) {
-        $self->{settings}{providers}{$self->_provider}{$default} ||= $self->config->{$default};
-    }
+    my $merge = Hash::Merge->new('LEFT_PRECEDENT');
+    my $config = $merge->merge($self->{settings}{providers}{$self->_provider}, $self->config);
+    $self->{settings}{providers}{$self->_provider} = $config;
 
     my $protocol_version = $self->provider_settings->{version} || 2;
     $self->{protocol_version} = $protocol_version;


### PR DESCRIPTION
Replace config ||= with Hash::Merge. Why? When I submit my pull request for AzureAD, users are going

to want to supply ONLY an updated authorize_url and access_token_url without touching the user_info url,
in order to supply their tenant ID in the URL, not required for the user_info which uses Graph API.

With ||= it'll basically scrub the defaults, replacing at the "urls" element level, thereby removing
elements that do not exist in the yml. I don't want this. Defaults should be defaults, which persist
if they're not defined in the config. :)